### PR TITLE
Bump dctlenv

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,3 +1,7 @@
+VersionLowerOrEqual() {
+    [ "$1" = "$(echo -e "$1\n$2" | sort -V | head -n 1)" ]
+}
+
 GetVersion() {
     if [ -n "${PARAM_VERSION}" ]; then
       echo -n "${PARAM_VERSION}"
@@ -8,13 +12,21 @@ GetVersion() {
 
 Install() {
     export DCTL_NO_VERSION_CHECK="true"
+
     BINPATH="${HOME}/.dctlenv/bin"
-    gpg --import driftctl_pubkey.pem
     if [ ! -d "${HOME}/.dctlenv" ]; then
-      git clone --depth 1 --branch v0.1.3 https://github.com/wbeuil/dctlenv ~/.dctlenv
+      git clone --depth 1 --branch v0.1.7 https://github.com/wbeuil/dctlenv ~/.dctlenv
     fi
+
     VERSION=$(GetVersion)
-    DCTLENV_PGP=1 "${BINPATH}/dctlenv" use "${VERSION}"
+
+    if VersionLowerOrEqual "${VERSION/v/}" "0.9.1"; then
+      "${BINPATH}/dctlenv" use "${VERSION}"
+    else
+      gpg --import driftctl_pubkey.pem
+      DCTLENV_PGP=1 "${BINPATH}/dctlenv" use "${VERSION}"
+    fi
+
     if [ ! -e /usr/local/bin/driftctl ]; then
       sudo ln -s "${BINPATH}/driftctl" /usr/local/bin/driftctl
     fi

--- a/src/tests/install.bats
+++ b/src/tests/install.bats
@@ -13,9 +13,21 @@ setup() {
     [ "$(GetVersion)" == "latest" ]
 }
 
-@test '3: test install' {
+@test '3: test install driftctl v0.5.0' {
     export PARAM_VERSION="v0.5.0"
     Install
     [ "$(which driftctl)" == "/usr/local/bin/driftctl" ]
     [ "$(driftctl version)" == "v0.5.0" ]
+}
+
+@test '3: test install driftctl v0.16.0' {
+    export PARAM_VERSION="v0.16.0"
+    Install
+    [ "$(which driftctl)" == "/usr/local/bin/driftctl" ]
+    [ "$(driftctl version)" == "v0.16.0" ]
+}
+
+@test '3: test install driftctl latest' {
+    Install
+    [ "$(which driftctl)" == "/usr/local/bin/driftctl" ]
 }


### PR DESCRIPTION
New version of dctlenv to use and adding test cases for PGP verification. This is after v0.9.1 that we introduce the PGP signature file.