### PR TITLE
chore: secrets scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 setup: true
 orbs:
+  prodsec: snyk/prodsec-orb@1.0
   orb-tools: circleci/orb-tools@11.5
   shellcheck: circleci/shellcheck@3.1
   bats: circleci/bats@1.1.0
@@ -12,6 +13,11 @@ filters: &filters
 workflows:
   lint-pack:
     jobs:
+      - prodsec/secrets-scan:
+          name: Scan repository for secrets
+          context:
+            - snyk-bot-slack
+          channel: group-infrastructure-as-code-alerts
       - orb-tools/lint:
           filters: *filters
       - orb-tools/pack:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.16.2
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
Adds secrets scanning to the repository. The scan runs in the CI/CD pipeline and is provide as a pre-commit hook as well.